### PR TITLE
Add missing header

### DIFF
--- a/src/base/root_of_unity.hpp
+++ b/src/base/root_of_unity.hpp
@@ -6,6 +6,7 @@
 
 #include "clir/expr.hpp"
 
+#include <array>
 #include <cmath>
 #include <complex>
 #include <utility>


### PR DESCRIPTION
Otherwise, build fails on Ubuntu 22.04.1 with oneAPI 2023.0.0

I'm also getting deprecation warnings regarding `local_accessor`. Perhaps the conditional there should be changed from `__INTEL_CLANG_COMPILER < 20230100` to `__INTEL_CLANG_COMPILER < 20230000`. But it's just a warning, so whatever.