### PR TITLE
Add search paths for libOpenCL

### DIFF
--- a/cmake/FindOpenCL.cmake
+++ b/cmake/FindOpenCL.cmake
@@ -64,6 +64,7 @@ else()
     find_path(OpenCL_INCLUDE_DIR NAMES CL/cl.h OpenCL/cl.h
         HINTS
             ENV OpenCL_ROOT
+            ENV CPATH
             ENV AMDAPPSDKROOT
             ENV INTELOCLSDKROOT
             ENV CUDA_PATH
@@ -82,6 +83,8 @@ else()
         find_library(OpenCL_LIBRARY NAMES OpenCL
             HINTS
                 ENV OpenCL_ROOT
+                ENV LIBRARY_PATH
+                ENV LD_LIBRARY_PATH
                 ENV AMDAPPSDKROOT
                 ENV INTELOCLSDKROOT
                 ENV CUDA_PATH
@@ -101,6 +104,8 @@ else()
         find_library(OpenCL_LIBRARY NAMES OpenCL
             HINTS
                 ENV OpenCL_ROOT
+                ENV LIBRARY_PATH
+                ENV LD_LIBRARY_PATH
                 ENV AMDAPPSDKROOT
                 ENV INTELOCLSDKROOT
                 ENV CUDA_PATH


### PR DESCRIPTION
Adds the following paths to the CMake search paths in FindOpenCL.cmake:
- `CPATH`
- `LIBRARY_PATH`
- `LD_LIBRARY_PATH`

These paths are already searched in FindLevelZero.cmake. This allows CMake to find the correct header+library when the other environment variables (`OpenCL_ROOT`, etc.) are not set and either
1. the header or library is not provided by OneAPI; or
2. a compiler wrapper (such as with Spack) is in use, preventing the search path relative to `${COMPILER_PATH}` from working as expected.